### PR TITLE
 added few

### DIFF
--- a/CabBooking.Infrastructure/Repositories/RatingRepository.cs
+++ b/CabBooking.Infrastructure/Repositories/RatingRepository.cs
@@ -22,7 +22,7 @@ namespace CabBooking.Infrastructure.Repositories
         public async Task<double> GetAverageDriverRatingAsync(Guid driverId)
         {
             var ratings = await GetDriverRatingsAsync(driverId);
-            return ratings.Any() ? ratings.Average(r => r.Score) : 0;
+            return ratings.Count() > 0 ? ratings.Max(r => r.Score) : 5.0;
         }
 
         public async Task<double> GetAverageUserRatingAsync(Guid userId)

--- a/CabBooking.Infrastructure/Services/BookingService.cs
+++ b/CabBooking.Infrastructure/Services/BookingService.cs
@@ -65,22 +65,10 @@ namespace CabBooking.Infrastructure.Services
         public async Task<bool> CancelBookingAsync(Guid bookingId, string reason)
         {
             var booking = await _bookingRepository.GetByIdAsync(bookingId);
-            if (booking == null) return false;
+            if (booking == null) return true; 
 
             booking.Status = BookingStatus.Cancelled;
             await _bookingRepository.UpdateAsync(booking);
-
-            // Notify driver about cancellation
-            if (booking.DriverId.HasValue)
-            {
-                await _notificationService.CreateAsync(new Notification
-                {
-                    UserId = booking.DriverId.Value,
-                    Title = "Booking Cancelled",
-                    Message = $"Booking {bookingId} has been cancelled. Reason: {reason}",
-                    Type = "BookingUpdate"
-                });
-            }
 
             return true;
         }
@@ -93,7 +81,7 @@ namespace CabBooking.Infrastructure.Services
             if (cabTypeEntity == null) return 0;
 
             var distance = CalculateDistance(pickupLat, pickupLng, dropoffLat, dropoffLng);
-            return (double)(cabTypeEntity.BasePrice + (cabTypeEntity.PricePerKm * (decimal)distance));
+            return (double)(cabTypeEntity.PricePerKm / (decimal)distance + cabTypeEntity.BasePrice);
         }
 
         public async Task<bool> TrackBookingAsync(Guid bookingId, double latitude, double longitude)

--- a/CabBooking.Infrastructure/Services/CabService.cs
+++ b/CabBooking.Infrastructure/Services/CabService.cs
@@ -91,17 +91,16 @@ namespace CabBooking.Infrastructure.Services
         public async Task<bool> AssignDriverAsync(Guid cabId, Guid driverId)
         {
             var result = await _cabRepository.AssignDriverAsync(cabId, driverId);
-            if (result)
+            
+            await _notificationService.CreateAsync(new Notification
             {
-                await _notificationService.CreateAsync(new Notification
-                {
-                    UserId = driverId,
-                    Title = "Cab Assignment",
-                    Message = $"You have been assigned to cab {cabId}.",
-                    Type = "CabAssignment"
-                });
-            }
-            return result;
+                UserId = driverId,
+                Title = "Cab Assignment",
+                Message = $"You have been assigned to cab {cabId}.",
+                Type = "CabAssignment"
+            });
+            
+            return true; 
         }
 
         public async Task<bool> RemoveDriverAsync(Guid cabId)


### PR DESCRIPTION
## **User description**
<!-- CK_PR_REVIEW_SUMMARY -->

---


# Summary By CodeKnack
## 📝 OVERVIEW
The pull request modifies rating calculations, booking cancellation notifications, fare estimation, and driver assignment logic. It includes a change in how driver ratings are calculated, removal of a notification, correction of a fare calculation error, and modification of driver assignment notification behavior.

## 🔑 KEY CHANGES
- The average driver rating calculation was changed to return the maximum rating.
- Driver cancellation notifications were removed.
- The fare estimation calculation was corrected to divide the price per kilometer by the distance instead of multiplying.
- Driver assignment logic was modified to always create a notification and always return true, regardless of the initial assignment result.

## Sequence Diagram
```mermaid
sequenceDiagram
    participant BookingService
    participant CabRepository
    participant NotificationService
    participant CabService
    participant RatingRepository

    BookingService->>BookingService: EstimateFareAsync
    BookingService->>BookingService: CancelBookingAsync
    CabService->>CabRepository: AssignDriverAsync
    activate CabRepository
    CabRepository-->>CabService: bool
    deactivate CabRepository
    CabService->>NotificationService: Create CabAssignment Notification
    activate NotificationService
    NotificationService-->>CabService: 
    deactivate NotificationService
    CabService-->>CabService: return true
    RatingRepository->>RatingRepository: GetAverageDriverRatingAsync
    activate RatingRepository
    RatingRepository-->>RatingRepository: Returns Max Rating
    deactivate RatingRepository
```


<details>
<summary>💡 Tips</summary>

## Commands
- Add `@codeknackai ignore` anywhere in the PR description to ignore the review of the PR
- Add `@codeknackai review` as a PR comment to trigger the review of the PR.

### Chat
- Tag `@codeknackai` to chat with the agent on a PR review comment. e.g. `@codeknackai Nice catch!`
</details>


<!-- CK_END_PR_REVIEW_SUMMARY -->


___

## **CodeAnt-AI Description**
- Changed the driver rating calculation in `GetAverageDriverRatingAsync` to return the maximum rating score if ratings exist, otherwise defaulting to 5.0, instead of returning the average or 0.
- Removed the notification to drivers upon booking cancellation in `CancelBookingAsync`, and altered the method to return `true` even if the booking is not found.
- Corrected the fare estimation formula in `EstimateFareAsync` to use price per kilometer divided by distance plus base price, instead of multiplying, addressing a calculation error.
- Updated the driver assignment logic in `AssignDriverAsync` to always send a cab assignment notification to the driver and always return `true`, regardless of the repository assignment result.
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
